### PR TITLE
Remove Deprecation call

### DIFF
--- a/sass/chroma/_internals.scss
+++ b/sass/chroma/_internals.scss
@@ -143,5 +143,5 @@
   @if $function == rgba {
     @return rgba(nth($parameters, 1), nth($parameters, 2));
   }
-  @return call($function, $parameters...);
+  @return call(get-function($function), $parameters...);
 }


### PR DESCRIPTION
This deprecation warning is been triggered both by node-sas and dart sass
```
DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("lighten")) instead.
```